### PR TITLE
97: fix dts generation

### DIFF
--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/dir/index.d.ts
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/dir/index.d.ts
@@ -1,0 +1,1 @@
+export declare const a = 1;

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/dir/index.js
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/dir/index.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const a = 1;
+exports.a = a;
+//# sourceMappingURL=index.js.map

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/dir/index.js.map
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/dir/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sources":["../../../../../../../../../Users/xavescor/projects/bobrik/src/fixtures/97-dts-reexports-bundler/dir/index.ts"],"sourcesContent":["export const a = 1;\n"],"names":[],"mappings":";;AAAO,MAAM,IAAI;;"}

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/reexports.d.ts
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/reexports.d.ts
@@ -1,0 +1,3 @@
+export { a } from "./dir/index.js";
+declare const _default: Promise<typeof import("./dir/index.js")>;
+export default _default;

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/reexports.js
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/reexports.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: "Module" } });
+const index = require("./dir/index.js");
+const reexports = Promise.resolve().then(() => require("./dir/index.js"));
+exports.a = index.a;
+exports.default = reexports;
+//# sourceMappingURL=reexports.js.map

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/reexports.js.map
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/cjs/reexports.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"reexports.js","sources":["../../../../../../../../Users/xavescor/projects/bobrik/src/fixtures/97-dts-reexports-bundler/reexports.ts"],"sourcesContent":["export { a } from \"./dir\";\n\nexport default import(\"./dir\");\n"],"names":[],"mappings":";;;AAEA,MAAe,YAAA,QAAA,QAAA,EAAA,KAAA,MAAA,QAAO,gBAAO,CAAA;;;"}

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/dir/index.d.mts
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/dir/index.d.mts
@@ -1,0 +1,1 @@
+export declare const a = 1;

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/dir/index.mjs
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/dir/index.mjs
@@ -1,0 +1,5 @@
+const a = 1;
+export {
+  a
+};
+//# sourceMappingURL=index.mjs.map

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/dir/index.mjs.map
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/dir/index.mjs.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.mjs","sources":["../../../../../../../../../Users/xavescor/projects/bobrik/src/fixtures/97-dts-reexports-bundler/dir/index.ts"],"sourcesContent":["export const a = 1;\n"],"names":[],"mappings":"AAAO,MAAM,IAAI;"}

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/reexports.d.mts
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/reexports.d.mts
@@ -1,0 +1,3 @@
+export { a } from "./dir/index.mjs";
+declare const _default: Promise<typeof import("./dir/index.mjs")>;
+export default _default;

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/reexports.mjs
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/reexports.mjs
@@ -1,0 +1,7 @@
+import { a } from "./dir/index.mjs";
+const reexports = import("./dir/index.mjs");
+export {
+  a,
+  reexports as default
+};
+//# sourceMappingURL=reexports.mjs.map

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/reexports.mjs.map
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/__compiled__/esm/reexports.mjs.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"reexports.mjs","sources":["../../../../../../../../Users/xavescor/projects/bobrik/src/fixtures/97-dts-reexports-bundler/reexports.ts"],"sourcesContent":["export { a } from \"./dir\";\n\nexport default import(\"./dir\");\n"],"names":[],"mappings":";AAEA,MAAe,YAAA,OAAO,iBAAO;"}

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/index.d.ts
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./__compiled__/cjs/reexports.js";

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/index.js
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./__compiled__/cjs/reexports.js");

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/index.mjs
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/index.mjs
@@ -1,0 +1,3 @@
+export * from "./__compiled__/esm/reexports.mjs";
+import Default from "./__compiled__/esm/reexports.mjs";
+export default Default;

--- a/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/package.json
+++ b/src/__dir_snapshots__/fef78ab3501ee949686c78baf2efd13971b3ed7b1cbe7630f970ad334984cf81/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "97-dts-reexports-bundler",
+  "type": "commonjs",
+  "version": "0.0.0",
+  "types": "./__compiled__/cjs/reexports.d.ts",
+  "module": "./__compiled__/esm/reexports.mjs",
+  "main": "./__compiled__/cjs/reexports.js",
+  "description": "",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./__compiled__/esm/reexports.d.mts",
+        "default": "./__compiled__/esm/reexports.mjs"
+      },
+      "require": {
+        "types": "./__compiled__/cjs/reexports.d.ts",
+        "default": "./__compiled__/cjs/reexports.js"
+      },
+      "types": "./__compiled__/cjs/reexports.d.ts",
+      "default": "./__compiled__/cjs/reexports.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -165,6 +165,17 @@ describe("bugs", () => {
     expect(tmpDir).toMatchDirSnapshot();
   });
 
+  test("97-dts-reexports-bundler", async ({ tmpDir }: { tmpDir: string }) => {
+    const res = await run({
+      outputDir: tmpDir,
+      sourceDir: "./src/fixtures/97-dts-reexports-bundler",
+    });
+
+    expect(res.error).toBeFalsy();
+    // @ts-expect-error
+    expect(tmpDir).toMatchDirSnapshot();
+  });
+
   test("4-babel-support", async ({ tmpDir }: { tmpDir: string }) => {
     const sourceDir = "./src/fixtures/4-babel-support";
 

--- a/src/fixtures/97-dts-reexports-bundler/dir/index.ts
+++ b/src/fixtures/97-dts-reexports-bundler/dir/index.ts
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/src/fixtures/97-dts-reexports-bundler/package.json
+++ b/src/fixtures/97-dts-reexports-bundler/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "97-dts-reexports-bundler",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": "./reexports.ts"
+}

--- a/src/fixtures/97-dts-reexports-bundler/reexports.ts
+++ b/src/fixtures/97-dts-reexports-bundler/reexports.ts
@@ -1,0 +1,3 @@
+export { a } from "./dir";
+
+export default import("./dir");

--- a/src/fixtures/97-dts-reexports-bundler/tsconfig.json
+++ b/src/fixtures/97-dts-reexports-bundler/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2018",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/src/tasks/buildTypesTask/inlineExtensions.ts
+++ b/src/tasks/buildTypesTask/inlineExtensions.ts
@@ -1,29 +1,44 @@
+import { join } from "node:path";
+
 // It needs for VSCode. It cannot resolve the import/export if it has no extension
 
 const importExportRegex =
   /(?:import|export)\s*(?:type\s*)?(?:(?:{\s*.+?\s*}|\*|[^{}\s]+)\s*from\s*)?["'](.+)["']/g;
 const dynamicImportRegex = /import\(["'](.+)["']\)/g;
 
-function addExtension(content: string, regex: RegExp, ext: string) {
+export type FileExists = (path: string) => boolean;
+
+function addExtension(
+  content: string,
+  regex: RegExp,
+  ext: string,
+  fileExists: FileExists,
+) {
   return content.replace(regex, (match, p1) => {
     if (!p1.startsWith(".")) {
       return match;
     }
+
     if (!p1.endsWith(".cjs") && !p1.endsWith(".mjs") && !p1.endsWith(".js")) {
-      return match.replace(p1, `${p1}${ext}`);
+      const file = `${p1}${ext}`;
+      if (fileExists(file)) return match.replace(p1, file);
+      const indexFile = "./" + join(p1, `index${ext}`);
+      if (fileExists(indexFile)) return match.replace(p1, indexFile);
+
+      return match;
     }
     return match;
   });
 }
 
-export function inlineExtensionsMjs(content: string) {
-  content = addExtension(content, importExportRegex, ".mjs");
-  content = addExtension(content, dynamicImportRegex, ".mjs");
+export function inlineExtensionsMjs(content: string, fileExists: FileExists) {
+  content = addExtension(content, importExportRegex, ".mjs", fileExists);
+  content = addExtension(content, dynamicImportRegex, ".mjs", fileExists);
   return content;
 }
 
-export function inlineExtensionsCjs(content: string) {
-  content = addExtension(content, importExportRegex, ".js");
-  content = addExtension(content, dynamicImportRegex, ".js");
+export function inlineExtensionsCjs(content: string, fileExists: FileExists) {
+  content = addExtension(content, importExportRegex, ".js", fileExists);
+  content = addExtension(content, dynamicImportRegex, ".js", fileExists);
   return content;
 }

--- a/src/tasks/buildTypesTask/inlineExtensons.test.ts
+++ b/src/tasks/buildTypesTask/inlineExtensons.test.ts
@@ -1,76 +1,83 @@
 import { describe, test, expect } from "vitest";
-import { inlineExtensionsCjs, inlineExtensionsMjs } from "./inlineExtensions.js";
+import {
+  type FileExists,
+  inlineExtensionsCjs,
+  inlineExtensionsMjs,
+} from "./inlineExtensions.js";
 
 const exts = [{ ext: ".cjs" }, { ext: ".mjs" }, { ext: ".js" }];
+
+const fileExists: FileExists = (path) => true;
+const fileIndexExists: FileExists = (path) => path.includes("index");
 
 describe("inlineExtensionsMjs", () => {
   describe("not changed", () => {
     describe("from file", () => {
       test.each(exts)("reexport all: ${ext}", ({ ext }) => {
         const content = `export * from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("reexport named: ${ext}", ({ ext }) => {
         const content = `export { resolveDirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("reexport named with alias: ${ext}", ({ ext }) => {
         const content = `export { resolveDirs as dirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import default: ${ext}", ({ ext }) => {
         const content = `import resolveDirs from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import named: ${ext}", ({ ext }) => {
         const content = `import { resolveDirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import named with alias: ${ext}", ({ ext }) => {
         const content = `import { resolveDirs as dirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import type: ${ext}", ({ ext }) => {
         const content = `import type { Dirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import type with alias: ${ext}", ({ ext }) => {
         const content = `import type { Dirs as Directories } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("dynamic import: ${ext}", ({ ext }) => {
         const content = `await import("./resolveDirs${ext}");`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
     });
 
     describe("from lib", () => {
       test("import from lib", () => {
         const content = `import { something } from "test-lib";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test("import type from lib", () => {
         const content = `import type { Something } from "test-lib";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test("dynamic import from lib", () => {
         const content = `await import("test-lib");`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
 
       test("export from lib", () => {
         const content = `export { something } from "test-lib";`;
-        expect(inlineExtensionsMjs(content)).toBe(content);
+        expect(inlineExtensionsMjs(content, fileExists)).toBe(content);
       });
     });
   });
@@ -79,55 +86,111 @@ describe("inlineExtensionsMjs", () => {
     test("reexport all without extension", () => {
       const input = `export * from "./resolveDirs";`;
       const expected = `export * from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("reexport named without extension", () => {
       const input = `export { resolveDirs } from "./resolveDirs";`;
       const expected = `export { resolveDirs } from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("reexport named with alias without extension", () => {
       const input = `export { resolveDirs as dirs } from "./resolveDirs";`;
       const expected = `export { resolveDirs as dirs } from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("import default without extension", () => {
       const input = `import resolveDirs from "./resolveDirs";`;
       const expected = `import resolveDirs from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("import named without extension", () => {
       const input = `import { resolveDirs } from "./resolveDirs";`;
       const expected = `import { resolveDirs } from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("import named with alias without extension", () => {
       const input = `import { resolveDirs as dirs } from "./resolveDirs";`;
       const expected = `import { resolveDirs as dirs } from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("import type without extension", () => {
       const input = `import type { Dirs } from "./resolveDirs";`;
       const expected = `import type { Dirs } from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("import type with alias without extension", () => {
       const input = `import type { Dirs as Directories } from "./resolveDirs";`;
       const expected = `import type { Dirs as Directories } from "./resolveDirs.mjs";`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
     });
 
     test("dynamic import without extension", () => {
       const input = `await import("./resolveDirs");`;
       const expected = `await import("./resolveDirs.mjs");`;
-      expect(inlineExtensionsMjs(input)).toBe(expected);
+      expect(inlineExtensionsMjs(input, fileExists)).toBe(expected);
+    });
+  });
+
+  describe("changed + index", () => {
+    test("reexport all without extension", () => {
+      const input = `export * from "./resolveDirs";`;
+      const expected = `export * from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("reexport named without extension", () => {
+      const input = `export { resolveDirs } from "./resolveDirs";`;
+      const expected = `export { resolveDirs } from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("reexport named with alias without extension", () => {
+      const input = `export { resolveDirs as dirs } from "./resolveDirs";`;
+      const expected = `export { resolveDirs as dirs } from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import default without extension", () => {
+      const input = `import resolveDirs from "./resolveDirs";`;
+      const expected = `import resolveDirs from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import named without extension", () => {
+      const input = `import { resolveDirs } from "./resolveDirs";`;
+      const expected = `import { resolveDirs } from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import named with alias without extension", () => {
+      const input = `import { resolveDirs as dirs } from "./resolveDirs";`;
+      const expected = `import { resolveDirs as dirs } from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import type without extension", () => {
+      const input = `import type { Dirs } from "./resolveDirs";`;
+      const expected = `import type { Dirs } from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import type with alias without extension", () => {
+      const input = `import type { Dirs as Directories } from "./resolveDirs";`;
+      const expected = `import type { Dirs as Directories } from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("dynamic import without extension", () => {
+      const input = `await import("./resolveDirs");`;
+      const expected = `await import("./resolveDirs/index.mjs");`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
     });
   });
 });
@@ -137,69 +200,69 @@ describe("inlineExtensionsCjs", () => {
     describe("from file", () => {
       test.each(exts)("reexport all: ${ext}", ({ ext }) => {
         const content = `export * from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("reexport named: ${ext}", ({ ext }) => {
         const content = `export { resolveDirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("reexport named with alias: ${ext}", ({ ext }) => {
         const content = `export { resolveDirs as dirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import default: ${ext}", ({ ext }) => {
         const content = `import resolveDirs from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import named: ${ext}", ({ ext }) => {
         const content = `import { resolveDirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import named with alias: ${ext}", ({ ext }) => {
         const content = `import { resolveDirs as dirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import type: ${ext}", ({ ext }) => {
         const content = `import type { Dirs } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("import type with alias: ${ext}", ({ ext }) => {
         const content = `import type { Dirs as Directories } from "./resolveDirs${ext}";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test.each(exts)("dynamic import: ${ext}", ({ ext }) => {
         const content = `await import("./resolveDirs${ext}");`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
     });
 
     describe("from lib", () => {
       test("import from lib", () => {
         const content = `import { something } from "test-lib";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test("import type from lib", () => {
         const content = `import type { Something } from "test-lib";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test("dynamic import from lib", () => {
         const content = `await import("test-lib");`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
 
       test("export from lib", () => {
         const content = `export { something } from "test-lib";`;
-        expect(inlineExtensionsCjs(content)).toBe(content);
+        expect(inlineExtensionsCjs(content, fileExists)).toBe(content);
       });
     });
   });
@@ -208,55 +271,111 @@ describe("inlineExtensionsCjs", () => {
     test("reexport all without extension", () => {
       const input = `export * from "./resolveDirs";`;
       const expected = `export * from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("reexport named without extension", () => {
       const input = `export { resolveDirs } from "./resolveDirs";`;
       const expected = `export { resolveDirs } from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("reexport named with alias without extension", () => {
       const input = `export { resolveDirs as dirs } from "./resolveDirs";`;
       const expected = `export { resolveDirs as dirs } from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("import default without extension", () => {
       const input = `import resolveDirs from "./resolveDirs";`;
       const expected = `import resolveDirs from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("import named without extension", () => {
       const input = `import { resolveDirs } from "./resolveDirs";`;
       const expected = `import { resolveDirs } from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("import named with alias without extension", () => {
       const input = `import { resolveDirs as dirs } from "./resolveDirs";`;
       const expected = `import { resolveDirs as dirs } from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("import type without extension", () => {
       const input = `import type { Dirs } from "./resolveDirs";`;
       const expected = `import type { Dirs } from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("import type with alias without extension", () => {
       const input = `import type { Dirs as Directories } from "./resolveDirs";`;
       const expected = `import type { Dirs as Directories } from "./resolveDirs.js";`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
     });
 
     test("dynamic import without extension", () => {
       const input = `await import("./resolveDirs");`;
       const expected = `await import("./resolveDirs.js");`;
-      expect(inlineExtensionsCjs(input)).toBe(expected);
+      expect(inlineExtensionsCjs(input, fileExists)).toBe(expected);
+    });
+  });
+
+  describe("changed + index", () => {
+    test("reexport all without extension", () => {
+      const input = `export * from "./resolveDirs";`;
+      const expected = `export * from "./resolveDirs/index.mjs";`;
+      expect(inlineExtensionsMjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("reexport named without extension", () => {
+      const input = `export { resolveDirs } from "./resolveDirs";`;
+      const expected = `export { resolveDirs } from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("reexport named with alias without extension", () => {
+      const input = `export { resolveDirs as dirs } from "./resolveDirs";`;
+      const expected = `export { resolveDirs as dirs } from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import default without extension", () => {
+      const input = `import resolveDirs from "./resolveDirs";`;
+      const expected = `import resolveDirs from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import named without extension", () => {
+      const input = `import { resolveDirs } from "./resolveDirs";`;
+      const expected = `import { resolveDirs } from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import named with alias without extension", () => {
+      const input = `import { resolveDirs as dirs } from "./resolveDirs";`;
+      const expected = `import { resolveDirs as dirs } from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import type without extension", () => {
+      const input = `import type { Dirs } from "./resolveDirs";`;
+      const expected = `import type { Dirs } from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("import type with alias without extension", () => {
+      const input = `import type { Dirs as Directories } from "./resolveDirs";`;
+      const expected = `import type { Dirs as Directories } from "./resolveDirs/index.js";`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
+    });
+
+    test("dynamic import without extension", () => {
+      const input = `await import("./resolveDirs");`;
+      const expected = `await import("./resolveDirs/index.js");`;
+      expect(inlineExtensionsCjs(input, fileIndexExists)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
tsc doesn't generate lib -> lib/index.js if mode is bundler. But it is affected in vscode if the bundled d.ts doesn't have the full paths. We need to add index.js/mjs manually

resolves #97 