### PR TITLE
104: move optional deps to peerDeps to avoid the random installation not required modules into user's libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Only ESM/TS entry points are currently supported in exports. While [conditional 
 Currently, we support all `bin` [specifications](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin) except for `sh` files. Also, we guarantee that the bin files will execute as expected.
 
 ## FAQ
+### SmartBundle have an issue
+Please, look at the [known fixable issues](./docs/isses.md) before creating your own one. Some bugs already have a solution but cannot be fixed without user action.
+
 ### Why don't you minify the output?
 Minification is typically needed only for production. During development, readable, unminified output helps with debugging.
 

--- a/docs/isses.md
+++ b/docs/isses.md
@@ -1,0 +1,6 @@
+# @babel/core is installed by SmartBundle
+The SmartBundle versions under v0.11.1 have the @babel/core dep in its optionalDependencies. Pnpm and other package managers can install it because it is acceptable behaviour.
+
+pnpm issue: https://github.com/pnpm/pnpm/issues/5928
+
+Please, update up to any version above v0.11.1 and reinstall the SmartBundle package. It should remove the @babel/core from your project.

--- a/package.json
+++ b/package.json
@@ -50,9 +50,17 @@
     "yargs": "^17.7.2",
     "zod": "^3.23.8"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@babel/core": "^7.26.0",
     "typescript": "^5.6.3"
+  },
+  "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
   },
   "exports": "./src/index.ts"
 }

--- a/src/packageJson.ts
+++ b/src/packageJson.ts
@@ -190,6 +190,7 @@ function createPackageJsonSchema(sourceDir: string) {
     unpkg: z.any().optional(),
     homepage: z.any().optional(),
     babel: z.any().optional(),
+    peerDependenciesMeta: z.any().optional(),
   });
 }
 type PackageJsonSchema = ReturnType<typeof createPackageJsonSchema>;

--- a/src/writePackageJson.ts
+++ b/src/writePackageJson.ts
@@ -103,6 +103,7 @@ export async function writePackageJson(
     unpkg: parsed.unpkg,
     homepage: parsed.homepage,
     devDependencies: parsed.devDependencies,
+    peerDependenciesMeta: parsed.peerDependenciesMeta,
   };
 
   await writeFile(`${outDir}/package.json`, JSON.stringify(res, null, 2));


### PR DESCRIPTION
resolves #104 

- move optional deps to peerDeps+peerDepsMeta(optional)
- peerDepsMeta support

user should reinstall smartbandle because pnpm hasn't removed pnpm lock if it is not needed.