### PR TITLE
Fix sb-dist-removal test fixture structure

### DIFF
--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -286,7 +286,6 @@ describe("bugs", () => {
       skipGitignore: true,
     });
 
-    console.error(res);
     expect(res.error).toBeFalsy();
     expect(tmpDir).toMatchDirSnapshot();
   });

--- a/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/package.json
+++ b/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-monorepo",
+  "private": true,
+  "type": "module"
+}

--- a/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/packages/my-package/package.json
+++ b/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/packages/my-package/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-package-sbsources",
+  "private": true,
+  "type": "module",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/packages/my-package/src/index.js
+++ b/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/packages/my-package/src/index.js
@@ -1,0 +1,1 @@
+export const hello = "world";

--- a/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/pnpm-workspace.yaml
+++ b/src/monorepo/createLinkPackages/__dir_snapshots__/createLinkPackages-removes-existing-sb-dist-22a6be73/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/package.json
+++ b/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-monorepo",
+  "private": true,
+  "type": "module"
+}

--- a/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/packages/my-package/package.json
+++ b/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/packages/my-package/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-package-sbsources",
+  "private": true,
+  "type": "module",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/packages/my-package/src/index.js
+++ b/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/packages/my-package/src/index.js
@@ -1,0 +1,1 @@
+export const hello = "world";

--- a/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/pnpm-workspace.yaml
+++ b/src/monorepo/createLinkPackages/__fixtures__/sb-dist-removal/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*


### PR DESCRIPTION
The test was failing because the fixture was missing proper monorepo structure. Added root package.json, pnpm-workspace.yaml, and source package with -sbsources suffix. Also removed debug console.error from build test.

related #144 