### PR TITLE
fix: normalize relative specifiers in .d.mts/.d.ts declarations

### DIFF
--- a/e2e/test-lib/reexport.ts
+++ b/e2e/test-lib/reexport.ts
@@ -1,1 +1,2 @@
 export { a } from "./imported.js";
+export type { Bar } from "./types.js";

--- a/e2e/test-lib/types.ts
+++ b/e2e/test-lib/types.ts
@@ -1,0 +1,1 @@
+export type Bar = { x: number };

--- a/e2e/typescript/bundler/index.ts
+++ b/e2e/typescript/bundler/index.ts
@@ -1,3 +1,4 @@
-import { a } from "test-lib/reexport";
+import { a, type Bar } from "test-lib/reexport";
 
-console.log(a);
+const bar: Bar = { x: 1 };
+console.log(a, bar.x);

--- a/e2e/typescript/bundler/tsconfig.json
+++ b/e2e/typescript/bundler/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "noEmit": true
   },
   "include": ["index.ts"]

--- a/e2e/typescript/node10/index.ts
+++ b/e2e/typescript/node10/index.ts
@@ -1,3 +1,4 @@
-import { a } from "test-lib/reexport";
+import { a, type Bar } from "test-lib/reexport";
 
-console.log(a);
+const bar: Bar = { x: 1 };
+console.log(a, bar.x);

--- a/e2e/typescript/node10/tsconfig.json
+++ b/e2e/typescript/node10/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "noEmit": true
   },
   "include": ["index.ts"]

--- a/e2e/typescript/node16cjs/index.ts
+++ b/e2e/typescript/node16cjs/index.ts
@@ -1,3 +1,4 @@
-import { a } from "test-lib/reexport";
+import { a, type Bar } from "test-lib/reexport";
 
-console.log(a);
+const bar: Bar = { x: 1 };
+console.log(a, bar.x);

--- a/e2e/typescript/node16cjs/tsconfig.json
+++ b/e2e/typescript/node16cjs/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "noEmit": true
   },
   "include": ["index.ts"]

--- a/e2e/typescript/node16es/index.ts
+++ b/e2e/typescript/node16es/index.ts
@@ -1,3 +1,4 @@
-import { a } from "test-lib/reexport";
+import { a, type Bar } from "test-lib/reexport";
 
-console.log(a);
+const bar: Bar = { x: 1 };
+console.log(a, bar.x);

--- a/e2e/typescript/node16es/tsconfig.json
+++ b/e2e/typescript/node16es/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "noEmit": true
   },
   "include": ["index.ts"]

--- a/src/__dir_snapshots__/build-ts-import-ccd39c12/__compiled__/esm/entrypoint.d.mts
+++ b/src/__dir_snapshots__/build-ts-import-ccd39c12/__compiled__/esm/entrypoint.d.mts
@@ -1,2 +1,2 @@
-export { a } from "./a.js";
+export { a } from "./a.mjs";
 export declare function helloWorld(): void;

--- a/src/tasks/buildTypesTask/inlineExtensions.ts
+++ b/src/tasks/buildTypesTask/inlineExtensions.ts
@@ -25,14 +25,6 @@ function transformAndExtractImports(
       return node;
     }
 
-    if (
-      importPath.endsWith(".cjs") ||
-      importPath.endsWith(".mjs") ||
-      importPath.endsWith(".js")
-    ) {
-      return node;
-    }
-
     const cleanedImportPath = importPath.replace(/\.[cm]?js$/, "");
 
     if (fileExists(`${cleanedImportPath}${dtsExt}`)) {

--- a/src/tasks/buildTypesTask/inlineExtensons.test.ts
+++ b/src/tasks/buildTypesTask/inlineExtensons.test.ts
@@ -9,60 +9,80 @@ import { createRequire } from "node:module";
 
 const { ts } = loadTypescriptApi(createRequire(import.meta.url));
 
-const exts = [{ ext: ".cjs" }, { ext: ".mjs" }, { ext: ".js" }];
+const inputExts = [".js", ".mjs", ".cjs"];
 
 const fileExists: FileExists = (path) => true;
 const fileIndexExists: FileExists = (path) => path.includes("index");
 
 describe("inlineExtensionsMjs", () => {
-  describe("not changed", () => {
+  describe("normalizes existing extension", () => {
     describe("from file", () => {
-      test.each(exts)("reexport all: ${ext}", ({ ext }) => {
-        const content = `export * from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("reexport all: %s", (inputExt) => {
+        const input = `export * from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `export * from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("reexport named: ${ext}", ({ ext }) => {
-        const content = `export { resolveDirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("reexport named: %s", (inputExt) => {
+        const input = `export { resolveDirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `export { resolveDirs } from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("reexport named with alias: ${ext}", ({ ext }) => {
-        const content = `export { resolveDirs as dirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("reexport named with alias: %s", (inputExt) => {
+        const input = `export { resolveDirs as dirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `export { resolveDirs as dirs } from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("import default: ${ext}", ({ ext }) => {
-        const content = `import resolveDirs from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import default: %s", (inputExt) => {
+        const input = `import resolveDirs from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `import resolveDirs from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("import named: ${ext}", ({ ext }) => {
-        const content = `import { resolveDirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import named: %s", (inputExt) => {
+        const input = `import { resolveDirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `import { resolveDirs } from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("import named with alias: ${ext}", ({ ext }) => {
-        const content = `import { resolveDirs as dirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import named with alias: %s", (inputExt) => {
+        const input = `import { resolveDirs as dirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `import { resolveDirs as dirs } from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("import type: ${ext}", ({ ext }) => {
-        const content = `import type { Dirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import type: %s", (inputExt) => {
+        const input = `import type { Dirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `import type { Dirs } from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("import type with alias: ${ext}", ({ ext }) => {
-        const content = `import type { Dirs as Directories } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import type with alias: %s", (inputExt) => {
+        const input = `import type { Dirs as Directories } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `import type { Dirs as Directories } from "./resolveDirs.mjs";\n`,
+        );
       });
 
-      test.each(exts)("dynamic import: ${ext}", ({ ext }) => {
-        const content = `await import("./resolveDirs${ext}");\n`;
-        expect(inlineExtensionsMjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("dynamic import: %s", (inputExt) => {
+        const input = `await import("./resolveDirs${inputExt}");\n`;
+        expect(inlineExtensionsMjs(ts, input, fileExists)).toBe(
+          `await import("./resolveDirs.mjs");\n`,
+        );
       });
     });
+  });
 
+  describe("not changed", () => {
     describe("from lib", () => {
       test("import from lib", () => {
         const content = `import { something } from "test-lib";\n`;
@@ -212,54 +232,74 @@ describe("inlineExtensionsMjs", () => {
 });
 
 describe("inlineExtensionsCjs", () => {
-  describe("not changed", () => {
+  describe("normalizes existing extension", () => {
     describe("from file", () => {
-      test.each(exts)("reexport all: ${ext}", ({ ext }) => {
-        const content = `export * from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("reexport all: %s", (inputExt) => {
+        const input = `export * from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `export * from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("reexport named: ${ext}", ({ ext }) => {
-        const content = `export { resolveDirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("reexport named: %s", (inputExt) => {
+        const input = `export { resolveDirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `export { resolveDirs } from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("reexport named with alias: ${ext}", ({ ext }) => {
-        const content = `export { resolveDirs as dirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("reexport named with alias: %s", (inputExt) => {
+        const input = `export { resolveDirs as dirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `export { resolveDirs as dirs } from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("import default: ${ext}", ({ ext }) => {
-        const content = `import resolveDirs from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import default: %s", (inputExt) => {
+        const input = `import resolveDirs from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `import resolveDirs from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("import named: ${ext}", ({ ext }) => {
-        const content = `import { resolveDirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import named: %s", (inputExt) => {
+        const input = `import { resolveDirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `import { resolveDirs } from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("import named with alias: ${ext}", ({ ext }) => {
-        const content = `import { resolveDirs as dirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import named with alias: %s", (inputExt) => {
+        const input = `import { resolveDirs as dirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `import { resolveDirs as dirs } from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("import type: ${ext}", ({ ext }) => {
-        const content = `import type { Dirs } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import type: %s", (inputExt) => {
+        const input = `import type { Dirs } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `import type { Dirs } from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("import type with alias: ${ext}", ({ ext }) => {
-        const content = `import type { Dirs as Directories } from "./resolveDirs${ext}";\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("import type with alias: %s", (inputExt) => {
+        const input = `import type { Dirs as Directories } from "./resolveDirs${inputExt}";\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `import type { Dirs as Directories } from "./resolveDirs.js";\n`,
+        );
       });
 
-      test.each(exts)("dynamic import: ${ext}", ({ ext }) => {
-        const content = `await import("./resolveDirs${ext}");\n`;
-        expect(inlineExtensionsCjs(ts, content, fileExists)).toBe(content);
+      test.each(inputExts)("dynamic import: %s", (inputExt) => {
+        const input = `await import("./resolveDirs${inputExt}");\n`;
+        expect(inlineExtensionsCjs(ts, input, fileExists)).toBe(
+          `await import("./resolveDirs.js");\n`,
+        );
       });
     });
+  });
 
+  describe("not changed", () => {
     describe("from lib", () => {
       test("import from lib", () => {
         const content = `import { something } from "test-lib";\n`;


### PR DESCRIPTION
## Summary

Fixes #170.

Relative specifiers ending in .js/.mjs/.cjs were passed through unchanged during declaration emit, so a NodeNext source `import "./types.js"` survived into a .d.mts as "./types.js". TypeScript (Node16/NodeNext) resolving "./types.js" from a .d.mts only checks for types.d.ts (not types.d.mts), dropping the referenced module/augmentation with TS2307.

## Root cause

`addExtension` in `src/tasks/buildTypesTask/inlineExtensions.ts` early-returned for specifiers already ending in .js/.mjs/.cjs.

## Fix

Removed the early-return. Already-extensioned relative specifiers now flow through the existing `cleanedImportPath` + `fileExists` guard, normalizing to the target system extension:
- ESM (.d.mts) → .mjs
- CJS (.d.ts) → .js

The `fileExists` guard only rewrites when the matching .d.mts/.d.ts exists in the output, so external/non-compiled files are left untouched.

## Tests (TDD: RED → GREEN)

- **Unit** `inlineExtensons.test.ts`: rewrote the `not changed → from file` block into `normalizes existing extension` (table: inputExt → targetExt). 102 passed.
- **E2E** `e2e/e2e.test.ts`: extended `test-lib` with a types-only module (`types.ts`) re-exported via "./types.js"; consumer fixtures now type-check with `skipLibCheck: false`. Was 18 FAIL (node16es + bundler) → now 33 passed.
- **Snapshot**: `build-ts-import` ESM `entrypoint.d.mts` updated "./a.js" → "./a.mjs" (CJS unchanged).
- Full `pnpm test`: 158 passed.

`skipLibCheck: false` is kept in consumer fixtures as a regression guard — with `true` the bug is masked (the unresolved type degrades to `any`).
